### PR TITLE
change indent distance to single space

### DIFF
--- a/scripts/nodejs/mdast/mdastrc
+++ b/scripts/nodejs/mdast/mdastrc
@@ -3,7 +3,7 @@
     "lint": {
         "unordered-list-marker-style": "consistent",
         "list-item-bullet-indent": true,
-        "list-item-indent": true,
+        "list-item-indent": "space",
         "list-item-spacing": true,
         "no-html": false,
         "maximum-line-length": true,


### PR DESCRIPTION
The default is "tab-size", which required me to insert 3 spaces. 